### PR TITLE
WIP: Create working dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/bower_components/
+/app/bower_components/
 
 /public/
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -21,10 +21,10 @@ module.exports = (grunt) ->
         bundleOptions:
           debug: true
         alias: [
-          './bower_components/backbone/backbone.js:backbone'
-          './bower_components/jquery/dist/jquery.js:jquery'
-          './bower_components/chaplin/chaplin.js:chaplin'
-          './bower_components/underscore/underscore.js:underscore'
+          './app/bower_components/backbone/backbone.js:backbone'
+          './app/bower_components/jquery/dist/jquery.js:jquery'
+          './app/bower_components/chaplin/chaplin.js:chaplin'
+          './app/bower_components/underscore/underscore.js:underscore'
         ]
 
     copy:
@@ -45,7 +45,7 @@ module.exports = (grunt) ->
           script: 'server/index.coffee'
       options:
         spawn: false
-        opts: ['node_modules/coffee-script/bin/coffee']
+        opts: ['node_modules/coffeeify/node_modules/coffee-script/bin/coffee']
 
     modernizr:
       app:

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "coffeeify": "~0.6.0",
     "handlebars": "~1.3.0",
     "hbsfy": "~1.3.2"
+  },
+  "dependencies": {
+    "express": "^4.2.0"
   }
 }


### PR DESCRIPTION
When pulling from the repo, I noticed that ‘grunt dev’ and ‘grunt
build’ failed. The main issue was that during the Browserify task,
Grunt was looking for a nonexistent bower_components directory.

This change appends app/ to the bower_components directory, giving a
valid file path.

Grunt also was unable to start the Express server as Express was not
listed as an npm dependency. This commit appends that, too. I do not
know which version is most desirable, however, and so just fetch the
latest version.

Now, after a git clone of the repo, 'grunt dev' works flawlessly.
