### PR TITLE
Explicitly set express's server port with grunt

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -86,6 +86,7 @@ module.exports = (grunt) ->
         options:
           background: false
       options:
+        port: process.env.PORT or 3000
         script: 'server/index.coffee'
         opts: ['node_modules/coffee-script/bin/coffee']
 

--- a/server/config.coffee
+++ b/server/config.coffee
@@ -3,7 +3,7 @@ module.exports =
     adminSegment: 'admin'
     apiSegment: 'api'
     salt: 'BUCKETS4LIFE!!1'
-    port: process.env.PORT or 3000
+    port: process.env.PORT
     env: process.env.NODE_ENV or 'development'
     templatePath: "#{__dirname}/../user/templates/"
   db: "mongodb://localhost/buckets_#{process.env.NODE_ENV or 'development'}"


### PR DESCRIPTION
My local environment is littered with lots of running servers
(I know, it's a bad habit for security! I'll try to be better.)
Anyway, in order to start this project, I tried to set env.PORT
to a freely available port on my machine before running
`grunt serve`. It worked:

``` bash
PORT=12345 grunt serve
```

Unfortunately, it didn't work with `grunt dev`, presumably
because background processes don't env variables from their parents
in the same way. Anyway, this pull request should make the following
work too:

``` bash
PORT=12345 grunt dev
```
