### PR TITLE
remove unnecessary _.pluck call in api/management

### DIFF
--- a/server/routes/api/management.coffee
+++ b/server/routes/api/management.coffee
@@ -18,7 +18,6 @@ app.get '/export', (req, res, next) ->
   async.parallel [
     (cb) ->
       Bucket.find {}, '-fields.id', (e, buckets) ->
-        ids = _.pluck buckets, 'id'
         async.map buckets, (bucket, callback) ->
           bkt = bucket.toJSON()
           Entry.find bucket: bkt.id, '-lastModified', (e, entries) ->


### PR DESCRIPTION
This looks like it was likely replaced with a call to `async.map` and is unnecessary as far as I can tell.
