### PR TITLE
Set JSON spaces to 2 in development mode

### DIFF
--- a/server/index.coffee
+++ b/server/index.coffee
@@ -73,6 +73,7 @@ class Buckets extends events.EventEmitter
     @app.set 'view engine', 'hbs'
     @app.set 'view cache', false
     @app.set 'query parser', 'simple' # reduces risk of MongoDB injection attack
+    @app.set 'json spaces', 2 if @config.get('env') is 'development'
 
     @app.use expressWinston.logger
       winstonInstance: logger


### PR DESCRIPTION
This is a proposal to prettify JSON output during development. I'm still getting used to the code and one of the things I noticed myself doing is experimenting with API calls. It's nice to have the output readable, at least for development.
