### PR TITLE
Allowed users to sort field types on buckets

### DIFF
--- a/client/source/models/fields.coffee
+++ b/client/source/models/fields.coffee
@@ -4,3 +4,4 @@ Collection = require 'lib/collection'
 module.exports = class Fields extends Collection
   url: '/api/fields/'
   model: Field
+  comparator: 'sort'

--- a/client/source/templates/buckets/fields.hbs
+++ b/client/source/templates/buckets/fields.hbs
@@ -11,10 +11,13 @@
 
 {{#if length}}
 
-  <ul class="fieldsList sortable list-group">
+  <ul id="sortable-fields" class="fieldsList sortable list-group">
   {{#each items}}
-    <li class="list-group-item">
-      <h3 class="list-group-item-heading"><a href="#edit">{{name}}</a></h2>
+    <li class="list-group-item field" data-field-slug="{{slug}}">
+      <div class="pull-right">
+        <a class="btn btn-link btn-icon btn-icon-small handle" href="#">{{icon 'cursor-move'}}</a>
+      </div>
+      <h3 class="list-group-item-heading"><a href="#edit">{{name}}</a></h3>
       <p class="list-group-item-text">
         <span class="label label-default">{{fieldType}}</span>
         <code>\{{{{slug}}<span></span>}}</code>

--- a/client/source/views/buckets/fields.coffee
+++ b/client/source/views/buckets/fields.coffee
@@ -21,6 +21,19 @@ module.exports = class BucketFieldsView extends View
     'add collection': 'render'
     'remove collection': 'render'
 
+  attach: ->
+    super
+    $sortable = @$el.find('#sortable-fields')
+    new Sortable $sortable.get(0),
+      handle: '.handle'
+      onUpdate: @updateSort
+
+  updateSort: =>
+    $sortable = @$el.find('#sortable-fields')
+    $sortable.children().each (i, li) =>
+      model = @collection.findWhere slug: $(li).data 'field-slug'
+      model.set sort: i if model
+
   getTemplateData: ->
     fieldTypes = [
         name: 'Add a field…'
@@ -70,6 +83,7 @@ module.exports = class BucketFieldsView extends View
     @listenToOnce field, 'change', (field) ->
       @subview('editField').dispose()
       @collection.add field, at: 0
+      @updateSort()
       @render()
 
   clickRemove: (e) ->

--- a/server/lib/mongoose-plugins.coffee
+++ b/server/lib/mongoose-plugins.coffee
@@ -1,0 +1,19 @@
+mongoose = require 'mongoose'
+_ = require 'underscore'
+
+module.exports.Sortable = (schema, options={}) ->
+  if options.embedded
+    parentSchema = schema
+    schema = parentSchema.path(options.embedded).schema
+
+  schema.isSortable = yes
+  schema.add
+    sort:
+      type: Number
+      default: 0
+      index: yes
+
+  if options.embedded
+    parentSchema.pre 'save', (next) ->
+      _.sortBy @[options.embedded], 'sort'
+      next()

--- a/server/models/bucket.coffee
+++ b/server/models/bucket.coffee
@@ -4,6 +4,7 @@ uniqueValidator = require 'mongoose-unique-validator'
 
 Route = require '../models/route'
 db = require '../lib/database'
+{Sortable} = require '../lib/mongoose-plugins'
 
 fieldSchema = new mongoose.Schema
   name:
@@ -100,6 +101,8 @@ bucketSchema.pre 'validate', (next) ->
   next()
 
 bucketSchema.plugin uniqueValidator, message: '“{VALUE}” is already taken.'
+bucketSchema.plugin Sortable
+bucketSchema.plugin Sortable, embedded: 'fields'
 
 bucketSchema.post 'remove', ->
   @model('Entry').remove(bucket: @_id).exec()


### PR DESCRIPTION
Introduced the Sortable plugin for Mongoose that sorts embedded arrays as well as introduces the necessary sort field and index.
Client-sided changes are based on #90.
