### PR TITLE
Introduced FieldData

### DIFF
--- a/client/source/models/entry.coffee
+++ b/client/source/models/entry.coffee
@@ -1,6 +1,7 @@
 Model = require 'lib/model'
 
 Bucket = require 'models/bucket'
+FieldData = require 'models/field_data'
 
 module.exports = class Entry extends Model
   defaults:
@@ -11,3 +12,13 @@ module.exports = class Entry extends Model
     slug: ''
     content: {}
   urlRoot: '/api/entries'
+
+  parse: (response) ->
+    for key, value of response
+      continue unless key is 'content'
+      content = {}
+      for slug, prop of value
+        content[slug] = new FieldData prop
+      response[key] = content
+    response
+

--- a/client/source/models/field_data.coffee
+++ b/client/source/models/field_data.coffee
@@ -1,0 +1,22 @@
+Model = require 'lib/model'
+
+module.exports = class FieldData extends Model
+  defaults:
+    data: value: null
+
+  getData: ->
+    @data
+
+  getValue: (path) ->
+    path = 'value' unless path
+    @get('data')[path]
+
+  setValue: (path, value) ->
+    unless value
+      value = path
+      path = 'value'
+
+    @get('data')[path] = value
+    # TODO should trigger some event, not sure about Chaplin
+    #@trigger 'change', {path: path, value: value}
+    @

--- a/client/source/views/entries/edit.coffee
+++ b/client/source/views/entries/edit.coffee
@@ -4,6 +4,7 @@ Model = require 'lib/model'
 PageView = require 'views/base/page'
 FormMixin = require 'views/base/mixins/form'
 FieldTypeInputView = require 'views/fields/input'
+FieldData = require 'models/field_data'
 Chaplin = require 'chaplin'
 
 tpl = require 'templates/entries/edit'
@@ -59,7 +60,7 @@ module.exports = class EntryEditView extends PageView
     content = @model.get('content')
 
     _.each @bucket.get('fields'), (field) =>
-      fieldValue = content[field.slug]
+      fieldValue = content[field.slug]?.getValue()
       fieldModel = new Model _.extend field, value: fieldValue
 
       @subview 'field_'+field.slug, new FieldTypeInputView
@@ -118,15 +119,15 @@ module.exports = class EntryEditView extends PageView
 
     content = {}
     for field in @bucket.get('fields')
-      content[field.slug] = @subview("field_#{field.slug}").getValue?()
-      continue if content[field.slug]
+      content[field.slug] = new FieldData fieldType: field.fieldType
+      content[field.slug].setValue @subview("field_#{field.slug}").getValue?()
+      continue if content[field.slug].getValue()
 
       data = @subview "field_#{field.slug}"
         .$el.formParams no
       simpleValue = data[field.slug]
 
-      content[field.slug] = if simpleValue? then simpleValue else data
-
+      content[field.slug].setValue if simpleValue? then simpleValue else data
     @model.set content: content
 
     status = @model.get 'status'

--- a/server/lib/renderer.coffee
+++ b/server/lib/renderer.coffee
@@ -39,7 +39,14 @@ module.exports = (hbs) ->
       for entry in entries
 
         # Make content attributes first-level tags, ie. `{{body}}` instead of `{{content.body}}`
-        entryJSON = _.extend entry, entry.content
+        # `{{body.data.value}}` becomes `{{body}}` while `{{body.data.html}}` becomes `{{body.html}}`
+        content = {}
+        for slug, fieldData of entry.content
+          for key, value of fieldData.data
+            newKey = if key is 'value' then slug else "#{slug}_#{key}"
+            content[newKey] = value
+
+        entryJSON = _.extend entry, content
         delete entryJSON.content
 
         try

--- a/server/models/entry.coffee
+++ b/server/models/entry.coffee
@@ -32,6 +32,14 @@ chrono.parsers.NowParser = (text, ref, opt) ->
 
   parser
 
+fieldDataSchema = new mongoose.Schema
+  fieldType:
+    type: String
+    required: yes
+  data:
+    type: Object
+    default: value: null
+
 entrySchema = new mongoose.Schema
   title:
     type: String


### PR DESCRIPTION
FieldData is an object nested inside an Entry's content.
Most implementation was on the client side, there's no FieldDataSchema in use right now because mongoose does not supported subdocuments outside of an Array. Having all FieldData in an array felt bad, what with not being able to access the data easily.

Every FieldData has a default `value` field inside its `data` object. This will contain default values. Future field types may populate the `data` object even further. Appropriate methods have been created.

User templates can still use `{{body}}` to access the value for a body. When the Markdown plugin middleware is finished, templates can also start using `{{body_html}}`.
