### PR TITLE
[Admin] Fixed bug where the admin panel wouldn't load

### DIFF
--- a/client/source/buckets.coffee
+++ b/client/source/buckets.coffee
@@ -26,10 +26,10 @@ module.exports = class BucketsApp extends Chaplin.Application
     mediator.user = new User @options.user if @options.user
     mediator.plugins = {}
 
-    if options.cloudinary
+    if @options.cloudinary
       $.cloudinary.config
-        api_key: options.cloudinary.api_key
-        cloud_name: options.cloudinary.cloud_name
+        api_key: @options.cloudinary.api_key
+        cloud_name: @options.cloudinary.cloud_name
 
     mediator.layout = new Layout
       title: 'Buckets'


### PR DESCRIPTION
I tried to hack on Buckts, the project looks awesome and I want to start to contribute, but I got this while starting the server using `grunt dev` in the dev-console (browser).

```
ReferenceError: options is not defined {stack: (...), message: "options is not defined"}
message: "options is not defined"
stack: (...)
-> get stack: function () { [native code] }
-> set stack: function () { [native code] }
-> __proto__: Error
```

thrown from `/admin/js/buckets.js` line 6301 (or view the diff of this PR to see the coffee lines ;))

I'm not sure whether this only happend to me, or this is a known
bug. Without the `this.options` the js would throw an error.
`options` is not defined.

Fixes Admin Panel on Chrome `40.0.2214.115` w/ `V8 3.30.33.16`

I'm not sure why this happens, I mean this is the main entry point...

I cannot be the only one who had these issues...

If this only with my setup, I would merge this anyways, just because it makes the code base cleaner.


#### Assembly

Should I open a bounty for this on Assembly or do these small bug fixes not matter in that regard?

Cheers,

Christian

***

### Screenshots
__This happens without the patch__
![before](https://i.imgur.com/H13VuV3.png)
_Yes I've run `grunt dev`..._

__Developer Console__
![error in console](https://i.imgur.com/9IcareL.png)

__With this 3 line change__
![after](https://i.imgur.com/KQsaeHq.png)