### PR TITLE
Added a pre-installation redirection to /admin

### DIFF
--- a/server/routes/frontend.coffee
+++ b/server/routes/frontend.coffee
@@ -61,7 +61,12 @@ app.all '/:frontend*?', (req, res, next) ->
   # We could use a $where here, but it's basically the same
   # since a basic $where scans all rows (plus this gives us more flexibility)
   Route.find {}, 'urlPattern urlPatternRegex template keys', sort: 'sort', (err, routes) ->
-    return next() unless routes?.length or config.has('catchAll') is yes
+    
+    unless routes?.length
+      logger.info 'No routes found. Redirecting to admin panel'
+      return res.redirect('/' + config.get('adminSegment'))
+
+    return next() if config.has('catchAll') is yes
 
     # dynamic renderTime helper
     # (startTime is set in index.coffee)


### PR DESCRIPTION
Instead of a 404 error Buckets will now redirect
the user to the admin dashboard on initial launch.

This approach uses the routes array to determine,
whether the app is in a pre-install state.

Performance wise does this commit change nothing, since
the if check has just been moved to another location.

A 302 'Found' code is sent along with the redirect (none permanent).

(See my [comment](https://assembly.com/buckets/bounties/261) on the bounty on Assembly for a brief explanation why I choose this approach)

Cheers,

Christian